### PR TITLE
refactor: concat accessToken, replaceToken

### DIFF
--- a/middleware/auth.middleware.js
+++ b/middleware/auth.middleware.js
@@ -31,70 +31,55 @@ function verifyAccessToken(req, res, next) {
 
   // access token 검증
   const accessToken = cookies.accessCookie;
-  jwt.verify(accessToken, process.env.ACCESS_TOKEN_KEY, (err) => {
-    // access token이 만료된 경우 다음 미들웨어에 expired 전달
+  jwt.verify(accessToken, process.env.ACCESS_TOKEN_KEY, async (err) => {
+    req.user = jwt.decode(accessToken); // 페이로드 전달
+
+    // access token이 만료된 경우
     if (err) {
       // 콘솔창에 만료됨을 알림
-      req.expired = true;
       console.error(err.name, ':', err.message);
-    }
-    req.user = jwt.decode(accessToken); // 페이로드 전달
-    next();
-  });
-}
+      try {
+        // DB에 저장된 리프레시 토큰 확인
+        const user = await Users.findByPk(req.user.userId);
+        const innerDatabaseRefreshToken = user.refreshToken;
 
-// 엑세스 토큰 만료 시 재발급을 위한 미들웨어
-async function replaceAccessToken(req, res, next) {
-  if (req.expired) {
-    try {
-      // DB에 저장된 리프레시 토큰 확인
-      const user = await Users.findByPk(req.user.userId);
-      const innerDatabaseRefreshToken = user.refreshToken;
+        // 엑세스 토큰에 저장된 리프레시 토큰 확인
+        const innerCookieRefreshToken = req.user.refreshToken;
 
-      // 엑세스 토큰에 저장된 리프레시 토큰 확인
-      const innerCookieRefreshToken = req.user.refreshToken;
+        // 토큰 일치 여부 확인
+        if (innerDatabaseRefreshToken !== innerCookieRefreshToken)
+          return res
+            .status(errors.refreshTokenDiff.status)
+            .send({ msg: errors.refreshTokenDiff.msg });
 
-      // 토큰 일치 여부 확인
-      if (innerDatabaseRefreshToken !== innerCookieRefreshToken)
-        return res
-          .status(errors.refreshTokenDiff.status)
-          .send({ msg: errors.refreshTokenDiff.msg });
+        // 리프레시 토큰 재발급 및 데이터베이스 저장
+        const refreshToken = getRefreshToken(user.nickname, user.userId);
+        const update = { refreshToken };
+        await Users.update(update, { where: { userId: user.userId } });
 
-      // // jwt 토큰 검증(해당 검증 방법이 굳이 필요한가 싶어 아래 방식으로 대체함)
-      // const refreshToken = user.refreshToken;
-      // jwt.verify(refreshToken, process.env.REFRESH_TOKEN_KEY, (err) => {
-      //   // refresh token이 만료된 경우 재로그인 안내
-      //   if (err)
-      //     return res.status(errors.expiredRefresh.status).send({ msg: errors.expiredRefresh.msg });
-      // });
-
-      // 토큰 재발급 및 쿠키로 보냄
-      res.cookie(
-        'accessCookie',
-        getAccessToken(user.nickname, user.userId, getRefreshToken(user.nickname, user.userId)),
-        {
+        // 엑세스 토큰 재발급 및 쿠키로 보냄
+        res.cookie('accessCookie', getAccessToken(user.nickname, user.userId, refreshToken), {
           httpOnly: true,
           maxAge: 24 * 60 * 60 * 1000, // 24시간
-        }
-      );
-      console.log('엑세스 토큰 만료로 재발급 진행');
-    } catch (err) {
-      console.error(err.name, ':', err.message);
-      return res.status(400).send({ msg: `${err.message}` });
+        });
+        console.log('엑세스 토큰 만료로 재발급 진행');
+      } catch (err) {
+        console.error(err.name, ':', err.message);
+        return res.status(400).send({ msg: `${err.message}` });
+      }
     }
-  }
-  res.locals.user = req.user
-  next();
+    res.locals.user = req.user;
+    next();
+  });
 }
 
 // // 게시글 수정 권한 검증을 위한 미들웨어
 // async function verificationForPosts(req, res, next) {
 //   const postId = req.params.postId;
-//   const password = req.body.password; // form 태그에서 받음
-//   const userId = req.accessTokenInfo.userId; // 미들웨어 토큰에서 가져온 정보
+//   const userId = res.locals.user.userId; // 미들웨어 토큰에서 가져온 정보
 
 //   try {
-//     const findPost = await Post.findByPk(postId);
+//     const findPost = await Posts.findByPk(postId);
 
 //     if (!findPost) return res.status(errors.noPost.status).send({ msg: errors.noPost.msg });
 
@@ -110,12 +95,11 @@ async function replaceAccessToken(req, res, next) {
 // // 댓글 수정 권한 검증을 위한 미들웨어
 // async function verificationForComments(req, res, next) {
 //   const { postId, commentId } = req.params;
-//   const password = req.body.password; // form태그에서 받음
-//   const userId = req.accessTokenInfo.userId; // 미들웨어 토큰에서 가져온 정보
+//   const userId = res.locals.user.userId; // 미들웨어 토큰에서 가져온 정보
 
 //   try {
-//     const findPost = await Post.findByPk(postId);
-//     const findComment = await Comment.findByPk(commentId);
+//     const findPost = await Posts.findByPk(postId);
+//     const findComment = await Comments.findByPk(commentId);
 
 //     if (!findPost) return res.status(errors.noPost.status).send({ msg: errors.noPost.msg });
 
@@ -137,7 +121,6 @@ module.exports = {
   getAccessToken,
   getRefreshToken,
   verifyAccessToken,
-  replaceAccessToken,
   // verificationForPosts,
   // verificationForComments,
 };

--- a/routes/users.router.js
+++ b/routes/users.router.js
@@ -113,17 +113,4 @@ router.get('/logout/:userId', async (req, res) => {
   }
 });
 
-// // 미들웨어 테스트를 위해 임시로 만든 기능입니다. (추후 삭제 가능)
-// const getUser = async (req, res) => {
-//   try {
-//     const userId = req.params.userId;
-//     const findUser = await Users.findByPk(userId);
-
-//     res.send(findUser);
-//   } catch (err) {
-//     console.error(err.name, ':', err.message);
-//     return res.status(400).send({ msg: `${err.message}` });
-//   }
-// };
-
 module.exports = router;


### PR DESCRIPTION
- verifyAccessToken 함수와 replaceAccessToken을 결합했습니다.
- users.router.js의 임시 코드를 제거했습니다.  

#### 📌 이후 검증 미들웨어 사용 시 verifyAccessToken만 적용해 주시면 되겠습니다.